### PR TITLE
add imports for Utc and Uuid

### DIFF
--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,5 +1,7 @@
 use actix_web::{web, HttpResponse};
+use chrono::Utc;
 use sqlx::PgPool;
+use uuid::Uuid;
 
 #[derive(serde::Deserialize)]
 pub struct FormData {


### PR DESCRIPTION
The imports (Utc and Uuid) are required for creating database entry